### PR TITLE
Implement request caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -133,6 +133,11 @@
       "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
       "dev": true
     },
+    "@types/memory-cache": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@types/memory-cache/-/memory-cache-0.2.0.tgz",
+      "integrity": "sha512-zDj+12RJaigGdbd00auPN2KXeQyPVv1ad+54Dcm+cVgiI7cWXher3s9fPZwHMLr1Ji2fcVhccmtDa2mIBlvnlQ=="
+    },
     "@types/mime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
@@ -4906,6 +4911,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memory-cache": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
+      "integrity": "sha1-eJCwHVLADI68nVM+H46xfjA0hxo="
     },
     "memorystream": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 	"dependencies": {
 		"@types/express": "^4.17.1",
 		"@types/express-session": "^1.15.15",
+		"@types/memory-cache": "^0.2.0",
 		"@types/node": "^12.11.1",
 		"@types/redis": "^2.8.14",
 		"@types/winston": "^2.4.4",
@@ -44,6 +45,7 @@
 		"flash": "^1.1.0",
 		"gulp": "^4.0.2",
 		"gulp-typescript": "^5.0.1",
+		"memory-cache": "^0.2.0",
 		"npm-run-all": "^4.1.5",
 		"redis": "^2.8.0",
 		"ts-node-dev": "^1.0.0-pre.43",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { setRequestId, ERR404, ERR500 } from "./middleware/errorPages"
 import staticFolder from "./config/static-folder"
 import session from "./config/session"
 import sessionCheck from "./middleware/sessionCheck"
+import memoryCache from "./middleware/memoryCache"
 import { readdirSync } from "fs"
 import { join } from "path"
 const app = express(),
@@ -19,9 +20,13 @@ router.use(sessionCheck)
 
 router.use(activityLogging)
 router.use(setRequestId)
+
+router.use(memoryCache(5000))
+
 readdirSync(join(__dirname, "routes")).forEach(function(file) {
 	require(join(__dirname, "routes", file))(router)
 })
+
 router.use(ERR404)
 router.use(errorLogging)
 router.use(ERR500)

--- a/src/middleware/memoryCache.ts
+++ b/src/middleware/memoryCache.ts
@@ -1,0 +1,37 @@
+import e from "express"
+
+import mcache from "memory-cache"
+
+const GET = "GET"
+const CACHE_PREFIX = "__express__"
+
+/**
+ * An in-memory request cache.
+ * @param duration in millisecond
+ * @returns an express middleware
+ */
+export default function cache(duration: number): e.Handler {
+	return function(req: e.Request, res: e.Response, next: e.NextFunction): void {
+		if (req.method.toUpperCase() !== GET) {
+			return next()
+		}
+
+		const key = CACHE_PREFIX + (req.originalUrl || req.url)
+
+		const cached = mcache.get(key)
+		if (cached) {
+			res.send(cached)
+			return
+		}
+
+		const sendResponse = res.send.bind(res)
+
+		// Overwritting the send method to cache the body before sending it
+		res.send = (body: any): e.Response => {
+			mcache.put(key, body, duration)
+			return sendResponse(body)
+		}
+
+		next()
+	}
+}


### PR DESCRIPTION
This PR fixes #8 .

Changes proposed in this pull request:

- Uses `memory-cache` module to cache GET requests